### PR TITLE
Avoid locking if source image is missing.

### DIFF
--- a/pyramid_frontend/images/view.py
+++ b/pyramid_frontend/images/view.py
@@ -41,6 +41,10 @@ class MissingOriginal(Exception):
 
 
 def process_image(settings, name, original_ext, chain, overwrite=False):
+    orig_path = original_path(settings, name, original_ext)
+    if not os.path.exists(orig_path):
+        raise MissingOriginal(path=orig_path, chain=chain)
+
     proc_path = processed_path(settings, name, original_ext, chain)
     if overwrite or (not os.path.exists(proc_path)):
         dest_dir = os.path.dirname(proc_path)
@@ -52,9 +56,6 @@ def process_image(settings, name, original_ext, chain, overwrite=False):
         lock = FileLock(proc_path + '.lock')
         with lock:
             if overwrite or (not os.path.exists(proc_path)):
-                orig_path = original_path(settings, name, original_ext)
-                if not os.path.exists(orig_path):
-                    raise MissingOriginal(path=orig_path, chain=chain)
                 image_data = open(orig_path, 'rb')
                 chain.run(proc_path, image_data)
     return proc_path


### PR DESCRIPTION
We've had problems with uwsgi hanging indefinitely when trying to serve images from a vboxsf filesystem, when the images are missing.

Part of the problem is that it can't create a hard link on a vboxsf filesystem, so acquiring the lock hangs forever. But testing that is quite a bit more complicated and seems like it really should be handled by lockfile better, so I am not excited about adding the extra logic here.

The other part of the problem is that, unless I'm missing something, there is no reason to acquire the lock on the processed file before checking if the original file exists. So I moved the check for the original file up to the very beginning of `process_image`. It works around our problem at least some of the time, if not most, and the logic seems like an improvement even in normal situations by avoiding unnecessary file locking.
